### PR TITLE
Update 07.1 Text Classification notebook to resolve import errors and correct minor spelling error.

### DIFF
--- a/07.1 Text Classification.ipynb
+++ b/07.1 Text Classification.ipynb
@@ -231,7 +231,7 @@
    "source": [
     "classifiers = {'sgd': SGDClassifier(loss='hinge'),\n",
     "               'svm': SVC(),\n",
-    "               'random_forrest': RandomForestClassifier()}\n",
+    "               'random_forest': RandomForestClassifier()}\n",
     "\n",
     "for lbl, clf in classifiers.items():\n",
     "    clf.fit(X_train, y_train)\n",
@@ -1760,21 +1760,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/07.1 Text Classification.ipynb
+++ b/07.1 Text Classification.ipynb
@@ -338,6 +338,7 @@
    "source": [
     "from itertools import chain\n",
     "from keras.preprocessing.sequence import pad_sequences\n",
+    "import numpy as np\n",
     "\n",
     "chars = list(sorted(set(chain(*emotion_df['content']))))\n",
     "char_to_idx = {ch: idx for idx, ch in enumerate(chars)}\n",

--- a/07.1 Text Classification.ipynb
+++ b/07.1 Text Classification.ipynb
@@ -403,6 +403,7 @@
     "from keras.layers import Input, Conv1D, MaxPooling1D, Flatten, Dense, Dropout, Merge, LSTM\n",
     "from keras.models import Model\n",
     "from keras.layers.merge import Concatenate\n",
+    "from keras import regularizers\n",
     "\n",
     "def create_char_cnn_model(num_chars, max_sequence_len, num_labels):\n",
     "    char_input = Input(shape=(max_sequence_len, num_chars), name='input')\n",


### PR DESCRIPTION
I did a quick update of the notebook to add two import statements that were apparently missing:

- import numpy as np
- from keras import regularizers

Also corrected spelling: forrest to forest.

However, due to the way Jupyter works, it also updated all references from Python 2 to Python 3. This shouldn't matter at all when someone opens up the notebook in either version, however I wanted to call it out for the maintainer (Douwe Osinga?) just in case.  :-)
