### PR TITLE
Update 03.1 Using pre trained word embeddings.ipynb

### DIFF
--- a/03.1 Using pre trained word embeddings.ipynb
+++ b/03.1 Using pre trained word embeddings.ipynb
@@ -56,7 +56,7 @@
    "outputs": [],
    "source": [
     "MODEL = 'GoogleNews-vectors-negative300.bin'\n",
-    "path = get_file(MODEL + '.gz', 'https://s3.amazonaws.com/dl4j-distribution/%s.gz' % MODEL)\n",
+    "path = get_file(MODEL + '.gz', 'https://deeplearning4jblob.blob.core.windows.net/resources/wordvectors/%s.gz' % MODEL)\n",
     "if not os.path.isdir('generated'):\n",
     "    os.mkdir('generated')\n",
     "\n",


### PR DESCRIPTION
We've recently ran out of AWS credits and noticed that most of it is going to serving the GoogleNews word2vec vectors.  We'd appreciate it if you could change the link to our Azure hosted one instead.