### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ docopt==0.6.2             # via internetarchive
 docutils==0.14            # via botocore
 emoji==0.5.2
 entrypoints==0.3          # via nbconvert
-fiona==1.8.6              # via geopandas
+fiona==1.8.17              # via geopandas
 flickrapi==2.4.0
 gast==0.2.2               # via tensorflow
 gensim==3.8.0


### PR DESCRIPTION
Updating Fiona version to most recent version to resolve error when installing in venv3 virtual environment using pip:
    Complete output (2 lines):
    Failed to get options via gdal-config: [Errno 2] No such file or directory: 'gdal-config'
    A GDAL API version must be specified. Provide a path to gdal-config using a GDAL_CONFIG environment variable or use a GDAL_VERSION environment variable.
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.